### PR TITLE
Feat/queuefactory

### DIFF
--- a/Rebus.AzureQueues/AzureQueues/CloudQueueClientQueueFactory.cs
+++ b/Rebus.AzureQueues/AzureQueues/CloudQueueClientQueueFactory.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Queue;
+
+namespace Rebus.AzureQueues
+{
+    internal class CloudQueueClientQueueFactory : ICloudQueueFactory
+    {
+        private readonly ConcurrentDictionary<string, Task<CloudQueue>> _queues = new ConcurrentDictionary<string, Task<CloudQueue>>();
+        private readonly CloudQueueClient _cloudQueueClient;
+
+        public CloudQueueClientQueueFactory(CloudQueueClient cloudQueueClient)
+        {
+            _cloudQueueClient = cloudQueueClient;
+        }
+
+        private Task<CloudQueue> InternalQueueFactory(string queueName)
+        {
+            return Task.FromResult(_cloudQueueClient.GetQueueReference(queueName));
+        }
+
+        public Task<CloudQueue> GetQueue(string queueName)
+        {
+            return _queues.GetOrAdd(queueName, InternalQueueFactory);
+        }
+    }
+}

--- a/Rebus.AzureQueues/AzureQueues/ICloudQueueFactory.cs
+++ b/Rebus.AzureQueues/AzureQueues/ICloudQueueFactory.cs
@@ -7,8 +7,16 @@ using Microsoft.WindowsAzure.Storage.Queue;
 
 namespace Rebus.AzureQueues
 {
+    /// <summary>
+    /// An abstraction to provide instances of <see cref="CloudQueue"/>
+    /// </summary>
     public interface ICloudQueueFactory
     {
+        /// <summary>
+        /// Retrieve an instance of <see cref="CloudQueue"/> targeting the given queue
+        /// </summary>
+        /// <param name="queueName">The queue to retrieve a <see cref="CloudQueue"/> for</param>
+        /// <returns></returns>
         Task<CloudQueue> GetQueue(string queueName);
     }
 }

--- a/Rebus.AzureQueues/AzureQueues/ICloudQueueFactory.cs
+++ b/Rebus.AzureQueues/AzureQueues/ICloudQueueFactory.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage.Queue;
+
+namespace Rebus.AzureQueues
+{
+    public interface ICloudQueueFactory
+    {
+        Task<CloudQueue> GetQueue(string queueName);
+    }
+}


### PR DESCRIPTION
Fixes #1 

Public changes:

- Added a public interface `ICloudQueueFactory` which has the purpose of providing instances of `CloudQueue`
- Added a second constructor to `AzureStorageQueuesTransport` which `ICloudQueueFactory` as a parameter instead of `CloudStorageAccount`
- Added two extension methods to `StandardConfigurer<ITransport>` which take `ICloudQueueFactory` as a parameter 

Internal changes:

- Refactored `AzureStorageQueuesTransport` to use `ICloudQueueFactory` internally instead of a `CloudStorageAccount`
- Added an internal utility class `CloudQueueClientQueueFactory` which implements `ICloudQueueFactory` using an instance of `CloudQueueClient` (which is provided by `CloudStorageAccount`) 

No breaking changes