### PR TITLE
added messagerenewal after similar to azure service bus. It will exte…

### DIFF
--- a/Rebus.AzureQueues.Tests/Rebus.AzureQueues.Tests.csproj
+++ b/Rebus.AzureQueues.Tests/Rebus.AzureQueues.Tests.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus.AzureQueues.Tests</RootNamespace>
     <AssemblyName>Rebus.AzureQueues.Tests</AssemblyName>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -35,9 +35,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.AzureQueues\Rebus.AzureQueues.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
   <ItemGroup>
     <None Update="azure_storage_connection_string.txt">

--- a/Rebus.AzureQueues.Tests/TestConfig.cs
+++ b/Rebus.AzureQueues.Tests/TestConfig.cs
@@ -4,6 +4,7 @@ using Microsoft.Azure.Storage;
 using Rebus.AzureQueues.Transport;
 using Rebus.Config;
 using Rebus.Logging;
+using Rebus.Threading.SystemThreadingTimer;
 using Rebus.Time;
 
 namespace Rebus.AzureQueues.Tests
@@ -57,7 +58,8 @@ namespace Rebus.AzureQueues.Tests
                 queueName,
                 new NullLoggerFactory(),
                 new AzureStorageQueuesTransportOptions(),
-                new DefaultRebusTime()
+                new DefaultRebusTime(),
+                 new SystemThreadingTimerAsyncTaskFactory(new NullLoggerFactory())
             )
             .PurgeInputQueue();
     }

--- a/Rebus.AzureQueues.Tests/Transport/AzureStorageQueuesTransportFactory.cs
+++ b/Rebus.AzureQueues.Tests/Transport/AzureStorageQueuesTransportFactory.cs
@@ -4,6 +4,7 @@ using Rebus.AzureQueues.Transport;
 using Rebus.Config;
 using Rebus.Logging;
 using Rebus.Tests.Contracts.Transports;
+using Rebus.Threading.SystemThreadingTimer;
 using Rebus.Time;
 using Rebus.Transport;
 
@@ -22,7 +23,7 @@ namespace Rebus.AzureQueues.Tests.Transport
         {
             if (inputQueueAddress == null)
             {
-                var transport = new AzureStorageQueuesTransport(AzureConfig.StorageAccount, null, new ConsoleLoggerFactory(false), new AzureStorageQueuesTransportOptions(), new DefaultRebusTime());
+                var transport = new AzureStorageQueuesTransport(AzureConfig.StorageAccount, null, new ConsoleLoggerFactory(false), new AzureStorageQueuesTransportOptions(), new DefaultRebusTime(),new SystemThreadingTimerAsyncTaskFactory(new ConsoleLoggerFactory(false)));
 
                 transport.Initialize();
 
@@ -31,7 +32,7 @@ namespace Rebus.AzureQueues.Tests.Transport
 
             return _transports.GetOrAdd(inputQueueAddress, address =>
             {
-                var transport = new AzureStorageQueuesTransport(AzureConfig.StorageAccount, inputQueueAddress, new ConsoleLoggerFactory(false), new AzureStorageQueuesTransportOptions(), new DefaultRebusTime());
+                var transport = new AzureStorageQueuesTransport(AzureConfig.StorageAccount, inputQueueAddress, new ConsoleLoggerFactory(false), new AzureStorageQueuesTransportOptions(), new DefaultRebusTime(), new SystemThreadingTimerAsyncTaskFactory(new ConsoleLoggerFactory(false)));
 
                 transport.PurgeInputQueue();
 

--- a/Rebus.AzureQueues.Tests/Transport/RenewalTests.cs
+++ b/Rebus.AzureQueues.Tests/Transport/RenewalTests.cs
@@ -1,0 +1,102 @@
+﻿using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Logging;
+using System;
+using Rebus.Tests.Contracts;
+using System.Threading;
+using System.Threading.Tasks;
+using Rebus.Tests.Contracts.Extensions;
+using Rebus.Transport;
+using Rebus.AzureQueues.Transport;
+using Rebus.Tests.Contracts.Utilities;
+using Rebus.Messages;
+using Rebus.Extensions;
+using Rebus.Threading.SystemThreadingTimer;
+
+namespace Rebus.AzureQueues.Tests.Transport
+{
+    [TestFixture]
+    public class AzureQueuePeekLockRenewalTest : FixtureBase
+    {
+        static readonly string ConnectionString = AzureConfig.ConnectionString;
+        static readonly string QueueName = TestConfig.GetName("input");
+
+        readonly ConsoleLoggerFactory _consoleLoggerFactory = new ConsoleLoggerFactory(false);
+
+        BuiltinHandlerActivator _activator;
+        AzureStorageQueuesTransport _transport;
+        IBus _bus;
+        IBusStarter _busStarter;
+        TimeSpan _visibilityTimeout = TimeSpan.FromSeconds(20);
+        protected override void SetUp()
+        {
+            _transport = new AzureStorageQueuesTransport(AzureConfig.StorageAccount, QueueName, _consoleLoggerFactory, new AzureStorageQueuesTransportOptions(), new Time.DefaultRebusTime(), new SystemThreadingTimerAsyncTaskFactory(new ConsoleLoggerFactory(false)));
+
+            _transport.Initialize();
+            _transport.PurgeInputQueue();
+
+            _activator = new BuiltinHandlerActivator();
+
+            _busStarter = Configure.With(_activator)
+                .Logging(l => l.Use(new ListLoggerFactory(outputToConsole: true, detailed: true)))
+                .Transport(t => t.UseAzureStorageQueues(ConnectionString, QueueName, new AzureStorageQueuesTransportOptions()
+                {
+                    AutomaticPeekLockRenewalEnabled = true,
+                    InitialVisibilityDelay = _visibilityTimeout
+                }))
+                .Options(o =>
+                {
+                    o.SetNumberOfWorkers(1);
+                    o.SetMaxParallelism(1);
+                })
+                .Create();
+
+            _bus = _busStarter.Bus;
+
+            Using(_bus);
+        }
+
+
+        [Test]
+        public async Task ItWorks()
+        {
+            var gotMessage = new ManualResetEvent(false);
+
+            _activator.Handle<string>(async (bus, context, message) =>
+            {
+                Console.WriteLine($"Got message with ID {context.Headers.GetValue(Headers.MessageId)} - waiting timout + 30 secs minutes....");
+
+                
+                await Task.Delay(_visibilityTimeout + TimeSpan.FromSeconds(30));
+
+                Console.WriteLine("done waiting");
+
+             
+            });
+
+            _busStarter.Start();
+
+            await _bus.SendLocal("hej med dig min ven!");
+
+            //would appear after visibility timout - if it wasn't  extended
+            await Task.Delay(_visibilityTimeout + TimeSpan.FromSeconds(2));
+        
+            // see if queue is empty
+            using var scope = new RebusTransactionScope();
+
+            var message = await _transport.Receive(scope.TransactionContext, CancellationToken.None);
+
+            await scope.CompleteAsync();
+
+            if (message != null)
+            {
+                throw new AssertionException(
+                    $"Did not expect to receive a message - got one with ID {message.Headers.GetValue(Headers.MessageId)}");
+            }
+
+                    
+        }
+    }
+}

--- a/Rebus.AzureQueues/AzureQueues/Internals/MessageLockRenewer.cs
+++ b/Rebus.AzureQueues/AzureQueues/Internals/MessageLockRenewer.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.Azure.Storage.Queue;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rebus.AzureQueues.Internals
+{
+    class MessageLockRenewer
+    {
+        readonly CloudQueueMessage _message;
+        readonly CloudQueue _messageReceiver;
+
+        DateTimeOffset _nextRenewal;
+
+        public MessageLockRenewer(CloudQueueMessage message, CloudQueue messageReceiver)
+        {
+            _message = message;
+            _messageReceiver = messageReceiver;
+            _nextRenewal = GetTimeOfNextRenewal();
+        }
+
+        public string MessageId => _message.Id;
+
+        public bool IsDue => DateTimeOffset.Now >= _nextRenewal;
+
+        public async Task Renew()
+        {
+            // intentionally let exceptions bubble out here, so the caller can log it as a warning
+            await _messageReceiver.UpdateMessageAsync(_message, TimeSpan.FromMinutes(5), MessageUpdateFields.Visibility);
+
+            _nextRenewal = GetTimeOfNextRenewal();
+        }
+
+        DateTimeOffset GetTimeOfNextRenewal()
+        {
+            var now = DateTimeOffset.Now;
+
+            var remainingTime = LockedUntil - now;
+            var halfOfRemainingTime = TimeSpan.FromMinutes(0.5 * remainingTime.TotalMinutes);
+
+            return now + halfOfRemainingTime;
+        }
+
+        DateTimeOffset LockedUntil => _message.NextVisibleTime.Value;
+    }
+
+}

--- a/Rebus.AzureQueues/AzureQueues/Transport/AzureStorageQueuesTransport.cs
+++ b/Rebus.AzureQueues/AzureQueues/Transport/AzureStorageQueuesTransport.cs
@@ -263,6 +263,7 @@ namespace Rebus.AzureQueues.Transport
                 {
                     throw new RebusApplicationException(exception, $"Could not delete message with ID {messageId} and pop receipt {popReceipt} from the input queue");
                 }
+                _messageLockRenewers.TryRemove(messageId, out _);
             });
 
             context.OnAborted(ctx =>

--- a/Rebus.AzureQueues/Config/AzureStorageQueuesConfigurationExtensions.cs
+++ b/Rebus.AzureQueues/Config/AzureStorageQueuesConfigurationExtensions.cs
@@ -6,6 +6,7 @@ using Rebus.AzureQueues.Transport;
 using Rebus.Logging;
 using Rebus.Pipeline;
 using Rebus.Pipeline.Receive;
+using Rebus.Threading;
 using Rebus.Time;
 using Rebus.Timeouts;
 using Rebus.Transport;
@@ -108,9 +109,10 @@ Configure.With(...)
 
             configurer.Register(c =>
             {
+                var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
                 var rebusTime = c.Get<IRebusTime>();
-                return new AzureStorageQueuesTransport(queueFactory, inputQueueAddress, rebusLoggerFactory, options, rebusTime);
+                return new AzureStorageQueuesTransport(queueFactory, inputQueueAddress, rebusLoggerFactory, options, rebusTime, asyncTaskFactory);
             });
 
             if (options.UseNativeDeferredMessages)

--- a/Rebus.AzureQueues/Config/AzureStorageQueuesTransportOptions.cs
+++ b/Rebus.AzureQueues/Config/AzureStorageQueuesTransportOptions.cs
@@ -37,5 +37,14 @@ namespace Rebus.Config
         /// Should be set to <code>false</code> if your application is not authorized to create queues on the Azure Storage Account. 
         /// </summary>
         public bool AutomaticallyCreateQueues { get; set; } = true;
+
+        /// <summary>
+        /// Enables automatic peek lock renewal. Only enable this if you intend on handling messages for a long long time, and
+        /// DON'T intend on handling messages quickly - it will have an impact on message receive, so only enable it if you
+        /// need it. You should usually strive after keeping message processing times low, much lower than the 5 minute lease
+        /// you get with Azure Queue. Will not work with prefecth of messages.
+        /// </summary>
+        public bool AutomaticPeekLockRenewalEnabled { get; set; } = false;
+
     }
 }

--- a/Rebus.AzureQueues/Rebus.AzureQueues.csproj
+++ b/Rebus.AzureQueues/Rebus.AzureQueues.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus</RootNamespace>
     <AssemblyName>Rebus.AzureQueues</AssemblyName>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>mookid8000</Authors>
     <PackageLicenseUrl></PackageLicenseUrl>


### PR DESCRIPTION
…nd the visibility after half the 'hidden' time has passed. It will always extend with 5 minutes
I have updated the test project to .net core version 3.1 as 2.1 is out of support . (3.1 has support until dec. 2022)
Similarly I've updated the supported framework of the Rebus.AzureQueues from .net framework 4.61 to 4.62 as 4.61 has end of support in april 2022.

The message renewal is 1-1 with the Azure Servicebus - running in a background thread that is disposed with the transport.
The Task is only started if the AutomaticallyRenewal is enabled.
AutomaticallyRenewal  will not work with prefecthing.

It's not easy testing the renewal - as it runs directly on the Azure SDK. But I've had a single test failing before I started (renewal test)


---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
